### PR TITLE
List supported languages, not dialects

### DIFF
--- a/pytest_translations/__init__.py
+++ b/pytest_translations/__init__.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 
 def pytest_addoption(parser):

--- a/pytest_translations/po_spelling.py
+++ b/pytest_translations/po_spelling.py
@@ -23,7 +23,7 @@ def is_enchant_installed():
 
 if enchant:
     supported_languages = [
-        name
+        name.split('_')[0]
         for name, _ in enchant.list_dicts()
     ]
 else:


### PR DESCRIPTION
On macOS `enchant` returns a list of dialects and not languages:

```
(env) ~/src/github.com/Thermondo/thermondo-backend$ python3
Python 3.6.1 (default, Apr  4 2017, 09:40:51)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import enchant
>>> enchant.list_dicts()
[('de_DE', <Enchant: Myspell Provider>), ('en_AU', <Enchant: Myspell Provider>), ('en_GB', <Enchant: Myspell Provider>), ('en_US', <Enchant: Myspell Provider>), ('fr_FR', <Enchant: Myspell Provider>)
```

This PR adds a fix that makes sure that we strip the dialect part.

Some more context here: https://github.com/Thermondo/thermondo-backend/issues/7831