### PR TITLE
Update pytest to 3.2.5, remove stale `py` dependency

### DIFF
--- a/pytest_translations/mo_files.py
+++ b/pytest_translations/mo_files.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 import shutil
-from py.test.collect import File, Item
+from pytest import File, Item
 
 from pytest_translations.config import MARKER_NAME
 from pytest_translations.utils import TranslationException, open_po_file, open_mo_file, msgfmt

--- a/pytest_translations/po_files.py
+++ b/pytest_translations/po_files.py
@@ -1,4 +1,4 @@
-from py.test.collect import File, Item
+from pytest import File, Item
 
 from pytest_translations.config import MARKER_NAME
 from pytest_translations.po_spelling import PoSpellCheckingItem

--- a/pytest_translations/po_spelling.py
+++ b/pytest_translations/po_spelling.py
@@ -1,8 +1,7 @@
 import os
 import re
 
-import pytest
-from py.test.collect import File, Item
+from pytest import Item, skip
 
 from pytest_translations.config import MARKER_NAME
 from pytest_translations.utils import TranslationException
@@ -63,13 +62,13 @@ class PoSpellCheckingItem(Item):
 
     def runtest(self):
         if not enchant:
-            pytest.skip("enchant is not installed")
+            skip("enchant is not installed")
 
         if not self.language:
-            pytest.skip("no language defined in PO file")
+            skip("no language defined in PO file")
 
         if self.language not in supported_languages:
-            pytest.skip(
+            skip(
                 "aspell dictionary for language {} not found.".format(self.language)
             )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 -e .
 polib==1.0.8
-py==1.4.34
 pyenchant==1.6.11
-pytest==3.2.3
+pytest==3.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ exclude = docs,runtests.py,setup.py,env
 [pydocstyle]
 match-dir = (?!tests|env|docs|\.).*
 match = (?!setup).*.py
-add-ignore = D100,D101,D102,D103,D104
+add_ignore = D1

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     entry_points={
         'pytest11': [
@@ -33,7 +34,6 @@ setup(
         ]
     },
     install_requires=[
-        'py>=1.3.0',
         'polib>=1.0.5',
         'pyenchant>=1.6.0',
     ],


### PR DESCRIPTION
Hi @codingjoe 

Latest `py` release deprecated a lot of stuff:
http://py.readthedocs.io/en/latest/changelog.html#changelog

Library is in maintenance mode and not recommended to be used in new code anymore:
https://github.com/pytest-dev/py