### PR TITLE
Ignore &shy; entity because it's only meant for optional word breaks

### DIFF
--- a/pytest_translations/po_spelling.py
+++ b/pytest_translations/po_spelling.py
@@ -80,6 +80,8 @@ class PoSpellCheckingItem(Item):
         text = re.sub('{.*?}', '', text)
         # 2. remove everything between %( and )
         text = re.sub('\%\(.*?\)', '', text)
+        # 3. remove &shy; html entity
+        text = text.replace('&shy;', '')
 
         tokenizer = get_tokenizer(
             chunkers=[

--- a/test_translations.py
+++ b/test_translations.py
@@ -287,6 +287,25 @@ class TestPoSpellcheck(object):
             "*4 passed*",
         ])
 
+    def test_shy_entity(self, testdir):
+        testdir.makefile(
+            '.po',
+            """
+            msgid ""
+            msgstr ""
+            "Language: de\\n"
+
+            #: asdf.py:111
+            msgid "meeting"
+            msgstr "Ver&shy;ab&shy;redung"
+            """
+        )
+        result = testdir.runpytest('--translations', '-vvv', '-r', 's')
+        result.stdout.fnmatch_lines([
+            "*collected 4*",
+            "*4 passed*",
+        ])
+
     def test_pass(self, testdir):
         testdir.makefile(
             '.po',


### PR DESCRIPTION
The `&shy;` entity (soft hyphen) is an invisible entity that simply marks a place where the browser could make a word break and insert a hyphen if needed. This is nice for long words that might break the desired layout.
When using `&shy;` in translations the word should be treated as if it was without it during spell checking. E.g. `Reise&shy;kosten&shy;rück&shy;erstattung` should be treated as `Reisekostenrückerstattung`.

This PR erases any `&shy;` entities before spell chacking.