### PR TITLE
Add Python 3.10 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         pytest-version: [
           "pytest>=6.1,<6.2",
           "pytest>=6.2,<6.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        pytest-version: [
-          "pytest>=6.1,<6.2",
-          "pytest>=6.2,<6.3"
-        ]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,10 +34,6 @@ jobs:
         run: |
           pip install -U codecov
           pip install -r requirements-dev.txt
-
-      - name: installing ${{ matrix.pytest-version }}
-        run: |
-          pip install "${{ matrix.pytest-version }}"
 
       - name: running tests
         run: coverage run --source="pytest_translations" -m "pytest"

--- a/README.rst
+++ b/README.rst
@@ -103,8 +103,8 @@ For example:
 
 .. |version| image:: https://img.shields.io/pypi/v/pytest-translations.svg
    :target: https://pypi.python.org/pypi/pytest-translations/
-.. |ci| image:: https://api.travis-ci.org/Thermondo/pytest-translations.svg?branch=master
-   :target: https://travis-ci.org/Thermondo/pytest-translations
+.. |ci| image:: https://github.com/Thermondo/pytest-translations/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/Thermondo/pytest-translations/actions/workflows/ci.yml
 .. |coverage| image:: https://codecov.io/gh/Thermondo/pytest-translations/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/Thermondo/pytest-translations
 .. |license| image:: https://img.shields.io/badge/license-APL_2-blue.svg


### PR DESCRIPTION
pytest started to support Python 3.10 only in version 6.2.5 (see PR https://github.com/pytest-dev/pytest/pull/8540).

@syphar I do not remember what was the reason behind covering both 6.1 and 6.2 in test matrix, was there something breaking for Thermondo? Otherwise I'd suggest to drop this rule going forward.