### PR TITLE
Fix invalid syntax deprecation warning in regex

### DIFF
--- a/pytest_translations/po_spelling.py
+++ b/pytest_translations/po_spelling.py
@@ -79,7 +79,7 @@ class PoSpellCheckingItem(Item):
         # 1. replace everything between curly braces
         text = re.sub('{.*?}', '', text)
         # 2. remove everything between %( and )
-        text = re.sub('\%\(.*?\)', '', text)
+        text = re.sub(r'\%\(.*?\)', '', text)
         # 3. remove &shy; html entity
         text = text.replace('&shy;', '')
 


### PR DESCRIPTION
Solves

```
pytest_translations/po_spelling.py:82
  pytest-translations/pytest_translations/po_spelling.py:82: DeprecationWarning: invalid escape sequence '\%'
    text = re.sub('\%\(.*?\)', '', text)
```