### PR TITLE
Fix aspell installation docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ On Mac you can use brew to install:
 
 .. code:: bash
 
-    brew install aspell --with-lang-{en|de|CHOSE YOUR LANGUAGE CODES}
+    brew install aspell
     brew install enchant
 
 Usage


### PR DESCRIPTION
brew dropped `--with-lang` option and seems like they just include all the languages now by default:
https://github.com/Homebrew/homebrew-core/blob/master/Formula/aspell.rb#L22
